### PR TITLE
ModelServ: Lazily return a default response on Exception

### DIFF
--- a/modelservers/bert_squad/predictor.py
+++ b/modelservers/bert_squad/predictor.py
@@ -9,6 +9,7 @@ class Predictor(BasePredictor):
     def __init__(self):
         model = AutoModelForQuestionAnswering.from_pretrained("/model/model")
         tokenizer = AutoTokenizer.from_pretrained("/model/tokenizer")
+        self.default_response = "Perhaps the answer is 42."
         self.predictor = pipeline(
             "question-answering", model=model, tokenizer=tokenizer
         )
@@ -19,9 +20,8 @@ class Predictor(BasePredictor):
         question = payload["question"]
         context = payload.get("context", self.context)
 
-        default_response = "Perhaps the answer is 42."
         try:
             res = self.predictor({"question": question, "context": context})
         except Exception:
-            res = default_response
+            res = self.default_response
         return res

--- a/modelservers/bert_squad/predictor.py
+++ b/modelservers/bert_squad/predictor.py
@@ -9,12 +9,19 @@ class Predictor(BasePredictor):
     def __init__(self):
         model = AutoModelForQuestionAnswering.from_pretrained("/model/model")
         tokenizer = AutoTokenizer.from_pretrained("/model/tokenizer")
-        self.predictor = pipeline("question-answering", model=model, tokenizer=tokenizer)
+        self.predictor = pipeline(
+            "question-answering", model=model, tokenizer=tokenizer
+        )
         with open("/mounts/bert_context/paragraph.txt") as f:
             self.context = f.read()
 
     def predict(self, payload):
         question = payload["question"]
         context = payload.get("context", self.context)
-        res = self.predictor({"question": question, "context": context})
+
+        default_response = "Perhaps the answer is 42."
+        try:
+            res = self.predictor({"question": question, "context": context})
+        except Exception:
+            res = default_response
         return res


### PR DESCRIPTION
Ran into this when I tried to ask the model server demo some non-standard questions, such as

```
curl --data '{"question":"what is froggo"}' http://caroline-local-external.aws-test.local.spell.services/aws-test/bert_squad/predict
```