### PR TITLE
[Hypersearch] Update imports

### DIFF
--- a/hyper/cifar10_cnn.py
+++ b/hyper/cifar10_cnn.py
@@ -9,11 +9,11 @@ It gets to 75% validation accuracy in 25 epochs, and 79% after 50 epochs.
 
 from __future__ import print_function
 from tensorflow import keras
-from keras.datasets import cifar10
-from keras.preprocessing.image import ImageDataGenerator
-from keras.models import Sequential
-from keras.layers import Dense, Dropout, Activation, Flatten
-from keras.layers import Conv2D, MaxPooling2D
+from tensorflow.keras.datasets import cifar10
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Dropout, Activation, Flatten
+from tensorflow.keras.layers import Conv2D, MaxPooling2D
 import os
 import argparse
 

--- a/keras/mnist.py
+++ b/keras/mnist.py
@@ -1,11 +1,11 @@
 import tensorflow as tf
 import idx2numpy
-import keras
 import argparse
 
-from keras.models import Sequential
-from keras.datasets import mnist
-from keras.layers import Conv2D, Dense, MaxPooling2D, Activation, Flatten, Dropout
+from tensorflow import keras
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.datasets import mnist
+from tensorflow.keras.layers import Conv2D, Dense, MaxPooling2D, Activation, Flatten, Dropout
 
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Current examples don't work. I am not sure of the root cause (updating tensorflow?), but these changes allow the examples to be run successfully!